### PR TITLE
Fixed support for flex shapes in PostgreSQL Example

### DIFF
--- a/CLI/databases/postgresql/README.md
+++ b/CLI/databases/postgresql/README.md
@@ -144,13 +144,13 @@ The following file defines all the variables used in this system. For details on
 
 | Name | Version |
 |------|---------|
-| <a name="provider_oci"></a> [oci](#provider\_oci) | 4.51.0 |
+| <a name="provider_oci"></a> [oci](#provider\_oci) | 4.67.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_postgre01"></a> [postgre01](#module\_postgre01) | git::ssh://git@github.com/oracle-devrel/terraform-oci-cloudbricks-postgresql | v1.0.3 |
+| <a name="module_postgre01"></a> [postgre01](#module\_postgre01) | git::ssh://git@github.com/oracle-devrel/terraform-oci-cloudbricks-postgresql | v1.0.6 |
 
 ## Resources
 

--- a/CLI/databases/postgresql/main.tf
+++ b/CLI/databases/postgresql/main.tf
@@ -6,7 +6,7 @@
 
 
 module "postgre01" {
-  source = "git::ssh://git@github.com/oracle-devrel/terraform-oci-cloudbricks-postgresql?ref=v1.0.4"
+  source = "git::ssh://git@github.com/oracle-devrel/terraform-oci-cloudbricks-postgresql?ref=v1.0.6"
   ######################################## PROVIDER SPECIFIC VARIABLES ######################################
   tenancy_ocid     = var.tenancy_ocid
   region           = var.region
@@ -33,13 +33,18 @@ module "postgre01" {
   database_backup_policy_level = var.postgre01_database_backup_policy_level
   instance_backup_policy_level = var.postgre01_instance_backup_policy_level
 
-  postgresql_master_name  = var.postgre01_postgresql_master_name
-  postgresql_master_ad    = var.postgre01_postgresql_master_ad
-  postgresql_master_fd    = var.postgre01_postgresql_master_fd
-  postgresql_master_shape = var.postgre01_postgresql_master_shape
+  postgresql_master_name          = var.postgre01_postgresql_master_name
+  postgresql_master_ad            = var.postgre01_postgresql_master_ad
+  postgresql_master_fd            = var.postgre01_postgresql_master_fd
+  postgresql_master_shape         = var.postgre01_postgresql_master_shape
+  postgresql_master_is_flex_shape = var.postgre01_postgresql_master_is_flex_shape
+  postgresql_master_ocpus         = var.postgre01_postgresql_master_ocpus
+  postgresql_master_memory_in_gb  = var.postgre01_postgresql_master_memory_in_gb
 
   postgresql_hotstandby_is_flex_shape = var.postgre01_postgresql_hotstandby_is_flex_shape
   postgresql_hotstandby_shape         = var.postgre01_postgresql_hotstandby_shape
+  postgresql_hotstandby_ocpus         = var.postgre01_postgresql_hotstandby_ocpus
+  postgresql_hotstandby_memory_in_gb  = var.postgre01_postgresql_hotstandby_memory_in_gb
 
   postgresql_deploy_hotstandby1 = var.postgre01_postgresql_deploy_hotstandby1
   postgresql_standyby1_name     = var.postgre01_postgresql_standyby1_name

--- a/CLI/databases/postgresql/output.tf
+++ b/CLI/databases/postgresql/output.tf
@@ -6,11 +6,10 @@
 
 output "MasterNode" {
   description = "Master Node Information"
-  sensitive = true
-  value = module.postgre01.PostgreSQL_Master
+  value       = module.postgre01.PostgreSQL_Master
 }
 
 output "Username" {
   description = "Username for PostgreSQL"
-  value = module.postgre01.PostgreSQL_Username
+  value       = module.postgre01.PostgreSQL_Username
 }

--- a/CLI/databases/postgresql/system.tfvars
+++ b/CLI/databases/postgresql/system.tfvars
@@ -32,9 +32,14 @@ postgre01_postgresql_master_name          = "MY_MASTER_INSTANCE_NAME"
 postgre01_postgresql_master_ad            = "aBCD:RE-REGION-1-AD-1"
 postgre01_postgresql_master_fd            = "FAULT-DOMAIN-1"
 postgre01_postgresql_master_shape         = "VM.Standard2.2"
+postgre01_postgresql_master_is_flex_shape = false
+postgre01_postgresql_master_ocpus         = ""
+postgre01_postgresql_master_memory_in_gb  = ""
 
-postgre01_postgresql_hotstandby_is_flex_shape = false
 postgre01_postgresql_hotstandby_shape         = "VM.Standard2.1"
+postgre01_postgresql_hotstandby_is_flex_shape = false
+postgre01_postgresql_hotstandby_ocpus         = ""
+postgre01_postgresql_hotstandby_memory_in_gb  = ""
 
 postgre01_postgresql_deploy_hotstandby1 = true
 postgre01_postgresql_standyby1_name     = "MY_HOTSTANDBY1_INSTANCE_NAME"


### PR DESCRIPTION
Closes #19 

Flex shapes are now properly supported by providing a Boolean value for whether the shape provided is flex, then ocpus and memory must be specified. 

The backend brick could already handle this, but was missed in the frontend example implementation. 